### PR TITLE
refactor: handle overflow errors and add fuzzing

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -10,7 +10,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: false
       - run: cargo clippy -- --deny clippy::nursery --deny clippy::pedantic --deny clippy::cargo --allow clippy::missing-panics-doc
@@ -18,15 +18,26 @@ jobs:
     name: Testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: cargo test
+  fuzz:
+    name: Fuzzing
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-fuzz
+      - run: cargo fuzz run convert_from_uf2 -- -timeout=120
   formatting:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: false
       - run: cargo fmt -- --check

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -25,7 +25,7 @@ jobs:
   fuzz:
     name: Fuzzing
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-fuzz
-      - run: cargo fuzz run convert_from_uf2 -- -timeout=120
+      - run: cargo fuzz run convert_from_uf2 -- -max_total_time=120
   formatting:
     name: Formatting
     runs-on: ubuntu-latest

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "uf2-decode-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.uf2-decode]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "convert_from_uf2"
+path = "fuzz_targets/convert_from_uf2.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/convert_from_uf2.rs
+++ b/fuzz/fuzz_targets/convert_from_uf2.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use uf2_decode::convert_from_uf2;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = convert_from_uf2(data);
+});


### PR DESCRIPTION
I understand that the overflow is documented. However, I think that it is a bit unrealistic to assume that users will validate that the addresses are valid. Adding this error variant should reduce the likelihood of vulnerabilities due to improper use of this crate.